### PR TITLE
:id: Update release ID

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -38,7 +38,7 @@ jobs:
           devices: iPhone 13,iPad Pro,iPad Pro landscape
           fullpage: false
           noDesktop: true
-          releaseId: 132411332
+          releaseId: 236029200
           type: png
           url: ${{ env.PR_NUMBER }}
         env:


### PR DESCRIPTION
Since the previous release was spilling over after more than 1000 files - jobs were hitting the "file_count limited to 1000 assets per release" error (HTTP 422).

After creating a new release, the ID needs to be updated accordingly.