### PR TITLE
ci: scope gh-pages concurrency to the preview job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,6 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, closed ]
 
-# Serialise every gh-pages write (the PR preview deploy here, and the
-# push-to-main deploy in publish.yml) so they cannot race on the gh-pages branch.
-concurrency:
-  group: gh-pages
-  cancel-in-progress: false
-
 # Least privilege by default; each job widens as needed.
 permissions: {}
 
@@ -95,6 +89,12 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     name: Make sure it builds. Then show a preview.
+    # Serialise gh-pages writes with the push-to-main deploy (publish.yml shares
+    # this group). Scoped to this job so the rest of CI is not pulled into the
+    # group and cancelled on push-to-main.
+    concurrency:
+      group: gh-pages
+      cancel-in-progress: false
     permissions: write-all
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

The consolidated \`.github/workflows/ci.yml\` had a **workflow-level** \`concurrency: { group: gh-pages, cancel-in-progress: false }\`. Since \`ci.yml\` now also runs on push-to-main, that group collided with the separate \`publish.yml\` (also \`gh-pages\` group). GitHub only allows one running + one pending job per concurrency group, so a Publish run was observed cancelled.

## Fix

Move the \`concurrency\` block off the workflow and onto the single job that actually writes to \`gh-pages\` — the \`build\` job, which deploys the PR preview via \`rossjrw/pr-preview-action\`. This still serialises gh-pages writes against \`publish.yml\`'s push-to-main deploy, but stops the rest of CI (test, lint, console, screenshots) from being pulled into the shared group and cancelled on push-to-main.

Mirrors the shape already merged in Primajin/Gyros, where the block lives inside the preview-deploy job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)